### PR TITLE
Fix socketpairly() docs to match code

### DIFF
--- a/lib/IO/Pipely.pm
+++ b/lib/IO/Pipely.pm
@@ -432,16 +432,16 @@ Please read DESCRIPTION for detailed semantics and caveats.
   # the best conduit type available.
 
   my (
-    $side_a_read,  $side_b_read,
-    $side_a_write, $side_b_write,
+    $side_a_read, $side_a_write,
+    $side_b_read, $side_b_write,
   ) = socketpairly();
 
   # Create a bidirectional pipe-like thing using an INET socket
   # specifically.
 
   my (
-    $side_a_read,  $side_b_read,
-    $side_a_write, $side_b_write,
+    $side_a_read, $side_a_write,
+    $side_b_read, $side_b_write,
   ) = socketpairly(type => 'inet');
 
 =head1 DESCRIPTION
@@ -516,7 +516,7 @@ for one end, and read and write for the other.  On failure, it returns
 nothing.
 
   use IO::Pipely qw(socketpairly);
-  my ($a_read, $b_read, $a_write, $b_write) = socketpairly();
+  my ($a_read, $a_write, $b_read, $b_write) = socketpairly();
   die "socketpairly() failed: $!" unless $a_read;
 
 socketpairly() returns two extra "writer" handles.  They exist for the
@@ -525,7 +525,7 @@ pair.  The extra handles can be ignored whenever pipe() will never be
 used.  For example:
 
   use IO::Pipely qw(socketpairly);
-  my ($side_a, $side_b) = socketpairly( type => 'socketpair' );
+  my ($side_a, undef, $side_b, undef) = socketpairly( type => 'socketpair' );
   die "socketpairly() failed: $!" unless $side_a;
 
 When given a choice, it will prefer bidirectional sockets instead of
@@ -536,7 +536,7 @@ parameter.  See L</PIPE TYPES> for the types that can be used.  In
 this example, two unidirectional pipes wil be used instead of a more
 efficient pair of sockets:
 
-  my ($a_read, $a_write, $b_read, $b_write) = pipely(
+  my ($a_read, $a_write, $b_read, $b_write) = socketpairly(
     type => 'pipe',
   );
 


### PR DESCRIPTION
Partially reverts 0eebdd0dee0fa90bf47ca4e8ae4e0216d66ac785 where the
order of the list of handles returned by `socketpairly()` was changed
only in the documentation, but not the code.
