### PR TITLE
Avoid core Fcntl, Symbol upgrades and add CI to test this

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,106 @@
+name: Run Tests
+
+on:
+  push:
+    branches:
+      - '*'
+  pull_request:
+
+jobs:
+  dist:
+    name: Make distribution using Dist::Zilla
+    runs-on: ubuntu-latest
+    env:
+      RUN_NETWORK_TESTS: 1
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+      - name: Cache ~/perl5
+        uses: actions/cache@v5
+        with:
+          key: ${{ runner.os }}-dist-locallib
+          path: ~/perl5
+      - name: Perl version
+        run: |
+          perl -v
+      - name: Install cpanm
+        run: |
+          curl -L https://cpanmin.us | perl - --sudo App::cpanminus
+      - name: Install local::lib
+        run: |
+          cpanm --local-lib=~/perl5 local::lib && eval $(perl -I ~/perl5/lib/perl5/ -Mlocal::lib)
+      - name: Install Dist::Zilla
+        shell: bash
+        run: |
+          eval $(perl -I ~/perl5/lib/perl5/ -Mlocal::lib)
+          cpanm -n Dist::Zilla
+          dzil authordeps --missing | cpanm -n
+      - name: Make distribution
+        shell: bash
+        run: |
+          eval $(perl -I ~/perl5/lib/perl5/ -Mlocal::lib)
+          dzil build --in build-dir
+      - name: Release testing
+        shell: bash
+        run: |
+          eval $(perl -I ~/perl5/lib/perl5/ -Mlocal::lib)
+          dzil test --release
+      - name: Upload artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: dist
+          path: ./build-dir
+  test:
+    needs: dist
+    runs-on: ${{ matrix.os }}
+    env:
+      RUN_NETWORK_TESTS: 1
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, windows-latest, ubuntu-latest]
+        perl: ['5']
+        include:
+          - { os: 'ubuntu-latest', perl: "5.8"  }
+          - { os: 'ubuntu-latest', perl: "5.10" }
+          - { os: 'ubuntu-latest', perl: "5.12" }
+          - { os: 'ubuntu-latest', perl: "5.14" }
+          - { os: 'ubuntu-latest', perl: "5.16" }
+          - { os: 'ubuntu-latest', perl: "5.18" }
+          - { os: 'ubuntu-latest', perl: "5.20" }
+          - { os: 'ubuntu-latest', perl: "5.22" }
+          - { os: 'ubuntu-latest', perl: "5.24" }
+          - { os: 'ubuntu-latest', perl: "5.26" }
+          - { os: 'ubuntu-latest', perl: "5.28" }
+          - { os: 'ubuntu-latest', perl: "5.30" }
+          - { os: 'ubuntu-latest', perl: "5.32" }
+          - { os: 'ubuntu-latest', perl: "5.34" }
+          - { os: 'ubuntu-latest', perl: "5.36" }
+    name: Perl ${{ matrix.perl }} on ${{ matrix.os }}
+
+    steps:
+      - name: Get dist artifact
+        uses: actions/download-artifact@v7
+        with:
+          name: dist
+
+      - name: Set up perl
+        uses: shogo82148/actions-setup-perl@v1
+        if: matrix.os != 'windows-latest'
+        with:
+          perl-version: ${{ matrix.perl }}
+      - name: Set up perl (Strawberry)
+        uses: shogo82148/actions-setup-perl@v1
+        if: matrix.os == 'windows-latest'
+        with:
+          distribution: 'strawberry'
+
+      - run: perl -V
+
+      - name: Install Perl deps
+        run: |
+          cpanm --notest --installdeps .
+
+      - name: Run tests
+        run: |
+          cpanm --verbose --test-only .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,26 @@ on:
   pull_request:
 
 jobs:
+  perl-version:
+    name: Fetch available perl versions
+    runs-on: ubuntu-latest
+    steps:
+      - uses: shogo82148/actions-setup-perl@v1
+      - id: set-matrix
+        name: Generate matrix for perl versions
+        shell: perl {0}
+        run: |
+          use Actions::Core;
+          use JSON::PP;
+          use version;
+          my $perl_min_version = version->parse("v5.8");
+          my @versions = grep { version->parse("v$_") >= $perl_min_version }
+                         perl_versions(platform => 'linux');
+          my @include = map { +{ os => 'ubuntu-latest', perl => $_ } } @versions;
+          set_output(matrix_include => \@include);
+    outputs:
+      matrix_include: ${{ steps.set-matrix.outputs.matrix_include }}
+
   dist:
     name: Make distribution using Dist::Zilla
     runs-on: ubuntu-latest
@@ -51,7 +71,7 @@ jobs:
           name: dist
           path: ./build-dir
   test:
-    needs: dist
+    needs: [dist, perl-version]
     runs-on: ${{ matrix.os }}
     env:
       RUN_NETWORK_TESTS: 1
@@ -60,22 +80,7 @@ jobs:
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
         perl: ['5']
-        include:
-          - { os: 'ubuntu-latest', perl: "5.8"  }
-          - { os: 'ubuntu-latest', perl: "5.10" }
-          - { os: 'ubuntu-latest', perl: "5.12" }
-          - { os: 'ubuntu-latest', perl: "5.14" }
-          - { os: 'ubuntu-latest', perl: "5.16" }
-          - { os: 'ubuntu-latest', perl: "5.18" }
-          - { os: 'ubuntu-latest', perl: "5.20" }
-          - { os: 'ubuntu-latest', perl: "5.22" }
-          - { os: 'ubuntu-latest', perl: "5.24" }
-          - { os: 'ubuntu-latest', perl: "5.26" }
-          - { os: 'ubuntu-latest', perl: "5.28" }
-          - { os: 'ubuntu-latest', perl: "5.30" }
-          - { os: 'ubuntu-latest', perl: "5.32" }
-          - { os: 'ubuntu-latest', perl: "5.34" }
-          - { os: 'ubuntu-latest', perl: "5.36" }
+        include: ${{ fromJSON(needs.perl-version.outputs.matrix_include) }}
     name: Perl ${{ matrix.perl }} on ${{ matrix.os }}
 
     steps:

--- a/dist.ini
+++ b/dist.ini
@@ -4,6 +4,10 @@ author           = Rocco Caputo <rcaputo@cpan.org>
 license          = Perl_5
 copyright_holder = Rocco Caputo
 
+; authordep Pod::Coverage::TrustPod
+; authordep Test::Pod
+; authordep Test::Pod::Coverage
+; authordep Test::Pod::No404s
 [AutoPrereqs]
 [CheckPrereqsIndexed]
 [Prereqs::MatchInstalled::All]

--- a/dist.ini
+++ b/dist.ini
@@ -15,6 +15,9 @@ exclude = strict
 exclude = vars
 exclude = warnings
 exclude = base
+; Fcntl, Symbol are not dual-life.
+exclude = Fcntl
+exclude = Symbol
 
 [AutoMetaResources]
 bugtracker.rt     = 1

--- a/dist.ini
+++ b/dist.ini
@@ -19,6 +19,8 @@ exclude = strict
 exclude = vars
 exclude = warnings
 exclude = base
+; Carp is used in tests only.
+exclude = Carp
 ; Fcntl, Symbol are not dual-life.
 exclude = Fcntl
 exclude = Symbol


### PR DESCRIPTION
Fixes <https://rt.cpan.org/Public/Bug/Display.html?id=125056>.

- Add GitHub CI workflow
- Exclude `Fcntl`, `Symbol` from `Prereqs::MatchInstalled`
- Add authordep on `Test::Pod::No404s`
